### PR TITLE
#24 Implementation ContactDetails

### DIFF
--- a/lib/materia_commerce/commerces/commerces.ex
+++ b/lib/materia_commerce/commerces/commerces.ex
@@ -22,7 +22,6 @@ defmodule MateriaCommerce.Commerces do
   %{
     billing_address: nil,
     buyer_id: nil,
-    contract_details: [],
     contract_no: "0000-0000-0000",
     contracted_date: "",
     delivery_address: nil,
@@ -43,7 +42,6 @@ defmodule MateriaCommerce.Commerces do
   %{
     billing_address: nil,
     buyer_id: nil,
-    contract_details: [],
     contract_no: "0000-0000-0000",
     contracted_date: "",
     delivery_address: nil,
@@ -64,7 +62,6 @@ defmodule MateriaCommerce.Commerces do
   %{
     billing_address: nil,
     buyer_id: nil,
-    contract_details: [],
     contract_no: "0000-0000-0000",
     contracted_date: "",
     delivery_address: nil,
@@ -85,7 +82,6 @@ defmodule MateriaCommerce.Commerces do
   %{
     billing_address: nil,
     buyer_id: nil,
-    contract_details: [],
     contract_no: "1111-1111-1111",
     contracted_date: "",
     delivery_address: nil,
@@ -122,7 +118,6 @@ defmodule MateriaCommerce.Commerces do
   %{
   billing_address: nil,
   buyer_id: nil,
-  contract_details: [],
   contract_no: "0000-0000-0000",
   contracted_date: "",
   delivery_address: nil,
@@ -156,7 +151,6 @@ defmodule MateriaCommerce.Commerces do
   %{
   billing_address: nil,
   buyer_id: nil,
-  contract_details: [],
   contract_no: "TEST",
   contracted_date: "",
   delivery_address: nil,
@@ -194,7 +188,6 @@ defmodule MateriaCommerce.Commerces do
   %{
   billing_address: nil,
   buyer_id: nil,
-  contract_details: [],
   contract_no: "TEST-UPDATE",
   contracted_date: "",
   delivery_address: nil,
@@ -245,7 +238,6 @@ defmodule MateriaCommerce.Commerces do
   %{
   billing_address: nil,
   buyer_id: nil,
-  contract_details: [],
   contract_no: "0000-0000-0000",
   contracted_date: "",
   delivery_address: nil,
@@ -289,7 +281,6 @@ defmodule MateriaCommerce.Commerces do
   %{
     billing_address: nil,
     buyer_id: nil,
-    contract_details: [],
     contract_no: "0000-0000-0000",
     contracted_date: "",
     delivery_address: nil,
@@ -310,7 +301,6 @@ defmodule MateriaCommerce.Commerces do
   %{
     billing_address: nil,
     buyer_id: nil,
-    contract_details: [],
     contract_no: "0000-0000-0000",
     contracted_date: "",
     delivery_address: nil,
@@ -331,7 +321,6 @@ defmodule MateriaCommerce.Commerces do
   %{
     billing_address: nil,
     buyer_id: nil,
-    contract_details: [],
     contract_no: "1111-1111-1111",
     contracted_date: "",
     delivery_address: nil,
@@ -430,7 +419,6 @@ defmodule MateriaCommerce.Commerces do
   %{
   billing_address: nil,
   buyer_id: nil,
-  contract_details: [],
   contract_no: "0000-0000-0000",
   contracted_date: "",
   delivery_address: nil,
@@ -478,7 +466,6 @@ defmodule MateriaCommerce.Commerces do
   %{
   billing_address: nil,
   buyer_id: nil,
-  contract_details: [],
   contract_no: "0000-0000-0000",
   contracted_date: "",
   delivery_address: nil,
@@ -562,17 +549,17 @@ defmodule MateriaCommerce.Commerces do
       end
   end
 
-
   alias MateriaCommerce.Commerces.ContractDetail
 
   @doc """
   Returns the list of contract_details.
 
   ## Examples
-
-#      iex> list_contract_details()
-#      [%ContractDetail{}, ...]
-
+  iex(1)> contract_details = MateriaCommerce.Commerces.list_contract_details
+  iex(2)> view = MateriaCommerceWeb.ContractDetailView.render("index.json", %{contract_details: contract_details})
+  iex(3)> view = view |> Enum.map(fn x -> x =  Map.put(x, :price, to_string(x.price)); x = Map.put(x, :purchase_amount, to_string(x.purchase_amount)); x = Map.put(x, :merchandise_cost, to_string(x.merchandise_cost));  x = Map.put(x, :start_datetime, to_string(x.start_datetime)); x = Map.put(x, :end_datetime, to_string(x.end_datetime)); x = Map.delete(x, :inserted_at); x = Map.delete(x, :updated_at); x = Map.delete(x, :id) end)
+  iex(4)> Enum.count(view)
+  6
   """
   def list_contract_details do
     @repo.all(ContractDetail)
@@ -584,13 +571,44 @@ defmodule MateriaCommerce.Commerces do
   Raises `Ecto.NoResultsError` if the Contract detail does not exist.
 
   ## Examples
-
-#      iex> get_contract_detail!(123)
-#      %ContractDetail{}
-#
-#      iex> get_contract_detail!(456)
-#      ** (Ecto.NoResultsError)
-
+  iex(1)> Application.put_env(:materia_utils, :calender_locale, "Asia/Tokyo")
+  iex(1)> contract_detail = MateriaCommerce.Commerces.get_contract_detail!(1)
+  iex(2)> view = MateriaCommerceWeb.ContractDetailView.render("show.json", %{contract_detail: contract_detail})
+  iex(3)> view = [view] |> Enum.map(fn x -> x =  Map.put(x, :price, to_string(x.price)); x = Map.put(x, :purchase_amount, to_string(x.purchase_amount)); x = Map.put(x, :merchandise_cost, to_string(x.merchandise_cost));  x = Map.put(x, :start_datetime, to_string(x.start_datetime)); x = Map.put(x, :end_datetime, to_string(x.end_datetime)); x = Map.delete(x, :inserted_at); x = Map.delete(x, :updated_at); x = Map.delete(x, :id) end) |> List.first
+  %{
+  amount: 1,
+  category1: "Single Detail",
+  category2: nil,
+  category3: nil,
+  category4: nil,
+  color: nil,
+  contract_name: nil,
+  contract_no: "0000-0000-0000",
+  delivery_area: nil,
+  description: nil,
+  end_datetime: "2018-12-01 17:59:59.000000+09:00 JST Asia/Tokyo",
+  image_url: nil,
+  item_code: nil,
+  jan_code: nil,
+  lock_version: 0,
+  manufacturer: nil,
+  merchandise_cost: "",
+  model_number: nil,
+  name: nil,
+  price: "100",
+  purchase_amount: "",
+  size1: nil,
+  size2: nil,
+  size3: nil,
+  size4: nil,
+  start_datetime: "2018-11-01 18:00:00.000000+09:00 JST Asia/Tokyo",
+  tax_category: nil,
+  thumbnail: nil,
+  weight1: nil,
+  weight2: nil,
+  weight3: nil,
+  weight4: nil
+  }
   """
   def get_contract_detail!(id), do: @repo.get!(ContractDetail, id)
 
@@ -598,13 +616,45 @@ defmodule MateriaCommerce.Commerces do
   Creates a contract_detail.
 
   ## Examples
-
-#      iex> create_contract_detail(%{field: value})
-#      {:ok, %ContractDetail{}}
-#
-#      iex> create_contract_detail(%{field: bad_value})
-#      {:error, %Ecto.Changeset{}}
-
+  iex(1)> Application.put_env(:materia_utils, :calender_locale, "Asia/Tokyo")
+  iex(1)> attr = %{"contract_name" => "TEST1", "contract_no" => "0000-0000-0000", "start_datetime" => "2018-01-01 09:00:00","end_datetime" => "2999-12-31 23:59:59"}
+  iex(2)> {:ok, contract_detail} = MateriaCommerce.Commerces.create_contract_detail(attr)
+  iex(3)> view = MateriaCommerceWeb.ContractDetailView.render("show.json", %{contract_detail: contract_detail})
+  iex(4)> view = [view] |> Enum.map(fn x -> x =  Map.put(x, :price, to_string(x.price)); x = Map.put(x, :purchase_amount, to_string(x.purchase_amount)); x = Map.put(x, :merchandise_cost, to_string(x.merchandise_cost));  x = Map.put(x, :start_datetime, to_string(x.start_datetime)); x = Map.put(x, :end_datetime, to_string(x.end_datetime)); x = Map.delete(x, :inserted_at); x = Map.delete(x, :updated_at); x = Map.delete(x, :id) end) |> List.first
+  %{
+  amount: nil,
+  category1: nil,
+  category2: nil,
+  category3: nil,
+  category4: nil,
+  color: nil,
+  contract_name: "TEST1",
+  contract_no: "0000-0000-0000",
+  delivery_area: nil,
+  description: nil,
+  end_datetime: "3000-01-01 08:59:59+09:00 JST Asia/Tokyo",
+  image_url: nil,
+  item_code: nil,
+  jan_code: nil,
+  lock_version: 0,
+  manufacturer: nil,
+  merchandise_cost: "",
+  model_number: nil,
+  name: nil,
+  price: "",
+  purchase_amount: "",
+  size1: nil,
+  size2: nil,
+  size3: nil,
+  size4: nil,
+  start_datetime: "2018-01-01 18:00:00+09:00 JST Asia/Tokyo",
+  tax_category: nil,
+  thumbnail: nil,
+  weight1: nil,
+  weight2: nil,
+  weight3: nil,
+  weight4: nil
+  }
   """
   def create_contract_detail(attrs \\ %{}) do
     %ContractDetail{}
@@ -616,13 +666,46 @@ defmodule MateriaCommerce.Commerces do
   Updates a contract_detail.
 
   ## Examples
-
-#      iex> update_contract_detail(contract_detail, %{field: new_value})
-#      {:ok, %ContractDetail{}}
-#
-#      iex> update_contract_detail(contract_detail, %{field: bad_value})
-#      {:error, %Ecto.Changeset{}}
-
+  iex(1)> Application.put_env(:materia_utils, :calender_locale, "Asia/Tokyo")
+  iex(1)> attr = %{"id" => 1, "contract_name" => "TEST1", "contract_no" => "0000-0000-0000", "start_datetime" => "2018-01-01 09:00:00","end_datetime" => "2999-12-31 23:59:59"}
+  iex(2)> contract_detail = MateriaCommerce.Commerces.get_contract_detail!(1)
+  iex(3)> {:ok, contract_detail} = MateriaCommerce.Commerces.update_contract_detail(contract_detail, attr)
+  iex(4)> view = MateriaCommerceWeb.ContractDetailView.render("show.json", %{contract_detail: contract_detail})
+  iex(5)> view = [view] |> Enum.map(fn x -> x =  Map.put(x, :price, to_string(x.price)); x = Map.put(x, :purchase_amount, to_string(x.purchase_amount)); x = Map.put(x, :merchandise_cost, to_string(x.merchandise_cost));  x = Map.put(x, :start_datetime, to_string(x.start_datetime)); x = Map.put(x, :end_datetime, to_string(x.end_datetime)); x = Map.delete(x, :inserted_at); x = Map.delete(x, :updated_at); x = Map.delete(x, :id) end) |> List.first
+  %{
+  amount: 1,
+  category1: "Single Detail",
+  category2: nil,
+  category3: nil,
+  category4: nil,
+  color: nil,
+  contract_name: "TEST1",
+  contract_no: "0000-0000-0000",
+  delivery_area: nil,
+  description: nil,
+  end_datetime: "3000-01-01 08:59:59+09:00 JST Asia/Tokyo",
+  image_url: nil,
+  item_code: nil,
+  jan_code: nil,
+  lock_version: 0,
+  manufacturer: nil,
+  merchandise_cost: "",
+  model_number: nil,
+  name: nil,
+  price: "100",
+  purchase_amount: "",
+  size1: nil,
+  size2: nil,
+  size3: nil,
+  size4: nil,
+  start_datetime: "2018-01-01 18:00:00+09:00 JST Asia/Tokyo",
+  tax_category: nil,
+  thumbnail: nil,
+  weight1: nil,
+  weight2: nil,
+  weight3: nil,
+  weight4: nil
+  }
   """
   def update_contract_detail(%ContractDetail{} = contract_detail, attrs) do
     contract_detail
@@ -634,28 +717,810 @@ defmodule MateriaCommerce.Commerces do
   Deletes a ContractDetail.
 
   ## Examples
-
-#      iex> delete_contract_detail(contract_detail)
-#      {:ok, %ContractDetail{}}
-#
-#      iex> delete_contract_detail(contract_detail)
-#      {:error, %Ecto.Changeset{}}
-
+  iex(1)> Application.put_env(:materia_utils, :calender_locale, "Asia/Tokyo")
+  iex(1)> contract_detail = MateriaCommerce.Commerces.get_contract_detail!(1)
+  iex(2)> {:ok, contract} = MateriaCommerce.Commerces.delete_contract_detail(contract_detail)
+  iex(3)> list_contract_details = MateriaCommerce.Commerces.list_contract_details |> Enum.find(fn x -> x.id == 1 end)
+  nil
   """
   def delete_contract_detail(%ContractDetail{} = contract_detail) do
     @repo.delete(contract_detail)
   end
 
   @doc """
-  Returns an `%Ecto.Changeset{}` for tracking contract_detail changes.
+  主キーを想定したパラメータで現在のContractDetail情報を取得する
+  Contract -> 1: ContractDetail -> N の関係のため複数件を返す｡
 
-  ## Examples
-
-#      iex> change_contract_detail(contract_detail)
-#      %Ecto.Changeset{source: %ContractDetail{}}
-
+  iex(1)> Application.put_env(:materia_utils, :calender_locale, "Asia/Tokyo")
+  iex(1)> {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-12-17 09:00:00Z")
+  iex(2)> key_word_list = [{:contract_no, "0000-0000-0000"}]
+  iex(3)> contract_details = MateriaCommerce.Commerces.get_current_contract_detail_history(base_datetime, key_word_list)
+  iex(4)> view = MateriaCommerceWeb.ContractDetailView.render("index.json", %{contract_details: contract_details})
+  iex(5)> view = view |> Enum.map(fn x -> x =  Map.put(x, :price, to_string(x.price)); x = Map.put(x, :purchase_amount, to_string(x.purchase_amount)); x = Map.put(x, :merchandise_cost, to_string(x.merchandise_cost));  x = Map.put(x, :start_datetime, to_string(x.start_datetime)); x = Map.put(x, :end_datetime, to_string(x.end_datetime)); x = Map.delete(x, :inserted_at); x = Map.delete(x, :updated_at); x = Map.delete(x, :id) end)
+  [
+  %{
+    amount: 3,
+    category1: "Multiple Details:2 With Item",
+    category2: nil,
+    category3: nil,
+    category4: nil,
+    color: nil,
+    contract_name: nil,
+    contract_no: "0000-0000-0000",
+    delivery_area: nil,
+    description: nil,
+    end_datetime: "2019-01-01 17:59:59.000000+09:00 JST Asia/Tokyo",
+    image_url: nil,
+    item_code: "ICZ1000",
+    jan_code: nil,
+    lock_version: 0,
+    manufacturer: nil,
+    merchandise_cost: "",
+    model_number: nil,
+    name: nil,
+    price: "300",
+    purchase_amount: "",
+    size1: nil,
+    size2: nil,
+    size3: nil,
+    size4: nil,
+    start_datetime: "2018-12-01 18:00:00.000000+09:00 JST Asia/Tokyo",
+    tax_category: nil,
+    thumbnail: nil,
+    weight1: nil,
+    weight2: nil,
+    weight3: nil,
+    weight4: nil
+  },
+  %{
+    amount: 2,
+    category1: "Multiple Details:1",
+    category2: nil,
+    category3: nil,
+    category4: nil,
+    color: nil,
+    contract_name: nil,
+    contract_no: "0000-0000-0000",
+    delivery_area: nil,
+    description: nil,
+    end_datetime: "2019-01-01 17:59:59.000000+09:00 JST Asia/Tokyo",
+    image_url: nil,
+    item_code: nil,
+    jan_code: nil,
+    lock_version: 0,
+    manufacturer: nil,
+    merchandise_cost: "",
+    model_number: nil,
+    name: nil,
+    price: "200",
+    purchase_amount: "",
+    size1: nil,
+    size2: nil,
+    size3: nil,
+    size4: nil,
+    start_datetime: "2018-12-01 18:00:00.000000+09:00 JST Asia/Tokyo",
+    tax_category: nil,
+    thumbnail: nil,
+    weight1: nil,
+    weight2: nil,
+    weight3: nil,
+    weight4: nil
+  }
+  ]
   """
-  def change_contract_detail(%ContractDetail{} = contract_detail) do
-    ContractDetail.changeset(contract_detail, %{})
+  def get_current_contract_detail_history(base_datetime, key_word_list) do
+    MateriaUtils.Ecto.EctoUtil.list_current_history(@repo, ContractDetail, base_datetime, key_word_list)
+  end
+
+  @doc """
+  start_datetimeに指定した以降の先日付の登録データがある場合、削除する｡
+
+  iex(1)> Application.put_env(:materia_utils, :calender_locale, "Asia/Tokyo")
+  iex(1)> {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-12-17 09:00:00Z")
+  iex(2)> key_word_list = [{:contract_no, "0000-0000-0000"}]
+  iex(3)> MateriaCommerce.Commerces.delete_future_contract_detail_histories(base_datetime, key_word_list)
+  iex(4)> contract_details = MateriaCommerce.Commerces.list_contract_details
+  iex(5)> view = MateriaCommerceWeb.ContractDetailView.render("index.json", %{contract_details: contract_details})
+  iex(6)> view = view |> Enum.map(fn x -> x =  Map.put(x, :price, to_string(x.price)); x = Map.put(x, :purchase_amount, to_string(x.purchase_amount)); x = Map.put(x, :merchandise_cost, to_string(x.merchandise_cost));  x = Map.put(x, :start_datetime, to_string(x.start_datetime)); x = Map.put(x, :end_datetime, to_string(x.end_datetime)); x = Map.delete(x, :inserted_at); x = Map.delete(x, :updated_at); x = Map.delete(x, :id) end)
+  [
+  %{
+    amount: 1,
+    category1: "Single Detail",
+    category2: nil,
+    category3: nil,
+    category4: nil,
+    color: nil,
+    contract_name: nil,
+    contract_no: "0000-0000-0000",
+    delivery_area: nil,
+    description: nil,
+    end_datetime: "2018-12-01 17:59:59.000000+09:00 JST Asia/Tokyo",
+    image_url: nil,
+    item_code: nil,
+    jan_code: nil,
+    lock_version: 0,
+    manufacturer: nil,
+    merchandise_cost: "",
+    model_number: nil,
+    name: nil,
+    price: "100",
+    purchase_amount: "",
+    size1: nil,
+    size2: nil,
+    size3: nil,
+    size4: nil,
+    start_datetime: "2018-11-01 18:00:00.000000+09:00 JST Asia/Tokyo",
+    tax_category: nil,
+    thumbnail: nil,
+    weight1: nil,
+    weight2: nil,
+    weight3: nil,
+    weight4: nil
+  },
+  %{
+    amount: 2,
+    category1: "Multiple Details:1",
+    category2: nil,
+    category3: nil,
+    category4: nil,
+    color: nil,
+    contract_name: nil,
+    contract_no: "0000-0000-0000",
+    delivery_area: nil,
+    description: nil,
+    end_datetime: "2019-01-01 17:59:59.000000+09:00 JST Asia/Tokyo",
+    image_url: nil,
+    item_code: nil,
+    jan_code: nil,
+    lock_version: 0,
+    manufacturer: nil,
+    merchandise_cost: "",
+    model_number: nil,
+    name: nil,
+    price: "200",
+    purchase_amount: "",
+    size1: nil,
+    size2: nil,
+    size3: nil,
+    size4: nil,
+    start_datetime: "2018-12-01 18:00:00.000000+09:00 JST Asia/Tokyo",
+    tax_category: nil,
+    thumbnail: nil,
+    weight1: nil,
+    weight2: nil,
+    weight3: nil,
+    weight4: nil
+  },
+  %{
+    amount: 3,
+    category1: "Multiple Details:2 With Item",
+    category2: nil,
+    category3: nil,
+    category4: nil,
+    color: nil,
+    contract_name: nil,
+    contract_no: "0000-0000-0000",
+    delivery_area: nil,
+    description: nil,
+    end_datetime: "2019-01-01 17:59:59.000000+09:00 JST Asia/Tokyo",
+    image_url: nil,
+    item_code: "ICZ1000",
+    jan_code: nil,
+    lock_version: 0,
+    manufacturer: nil,
+    merchandise_cost: "",
+    model_number: nil,
+    name: nil,
+    price: "300",
+    purchase_amount: "",
+    size1: nil,
+    size2: nil,
+    size3: nil,
+    size4: nil,
+    start_datetime: "2018-12-01 18:00:00.000000+09:00 JST Asia/Tokyo",
+    tax_category: nil,
+    thumbnail: nil,
+    weight1: nil,
+    weight2: nil,
+    weight3: nil,
+    weight4: nil
+  },
+  %{
+    amount: 1,
+    category1: "Single Detail",
+    category2: nil,
+    category3: nil,
+    category4: nil,
+    color: nil,
+    contract_name: nil,
+    contract_no: "1111-1111-1111",
+    delivery_area: nil,
+    description: nil,
+    end_datetime: "3000-01-01 08:59:59.000000+09:00 JST Asia/Tokyo",
+    image_url: nil,
+    item_code: nil,
+    jan_code: nil,
+    lock_version: 0,
+    manufacturer: nil,
+    merchandise_cost: "",
+    model_number: nil,
+    name: nil,
+    price: "100",
+    purchase_amount: "",
+    size1: nil,
+    size2: nil,
+    size3: nil,
+    size4: nil,
+    start_datetime: "2018-01-01 18:00:00.000000+09:00 JST Asia/Tokyo",
+    tax_category: nil,
+    thumbnail: nil,
+    weight1: nil,
+    weight2: nil,
+    weight3: nil,
+    weight4: nil
+  }
+  ]
+  """
+  def delete_future_contract_detail_histories(base_datetime, key_word_list) do
+    MateriaUtils.Ecto.EctoUtil.delete_future_histories(@repo, ContractDetail, base_datetime, key_word_list)
+  end
+
+  @doc """
+  現在以前の直近のContractDetails情報を取得する
+  Contract -> 1: ContractDetail -> N の関係のため複数件を返す｡
+
+  iex(1)> Application.put_env(:materia_utils, :calender_locale, "Asia/Tokyo")
+  iex(1)> {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-12-17 09:00:00Z")
+  iex(2)> key_word_list = [{:contract_no, "0000-0000-0000"}]
+  iex(3)> contract_details = MateriaCommerce.Commerces.get_recent_contract_detail_history(base_datetime, key_word_list)
+  iex(4)> view = MateriaCommerceWeb.ContractDetailView.render("index.json", %{contract_details: contract_details})
+  iex(5)> view = view |> Enum.map(fn x -> x =  Map.put(x, :price, to_string(x.price)); x = Map.put(x, :purchase_amount, to_string(x.purchase_amount)); x = Map.put(x, :merchandise_cost, to_string(x.merchandise_cost));  x = Map.put(x, :start_datetime, to_string(x.start_datetime)); x = Map.put(x, :end_datetime, to_string(x.end_datetime)); x = Map.delete(x, :inserted_at); x = Map.delete(x, :updated_at); x = Map.delete(x, :id) end)
+  [
+  %{
+    amount: 3,
+    category1: "Multiple Details:2 With Item",
+    category2: nil,
+    category3: nil,
+    category4: nil,
+    color: nil,
+    contract_name: nil,
+    contract_no: "0000-0000-0000",
+    delivery_area: nil,
+    description: nil,
+    end_datetime: "2019-01-01 17:59:59+09:00 JST Asia/Tokyo",
+    image_url: nil,
+    item_code: "ICZ1000",
+    jan_code: nil,
+    lock_version: 0,
+    manufacturer: nil,
+    merchandise_cost: "",
+    model_number: nil,
+    name: nil,
+    price: "300",
+    purchase_amount: "",
+    size1: nil,
+    size2: nil,
+    size3: nil,
+    size4: nil,
+    start_datetime: "2018-12-01 18:00:00+09:00 JST Asia/Tokyo",
+    tax_category: nil,
+    thumbnail: nil,
+    weight1: nil,
+    weight2: nil,
+    weight3: nil,
+    weight4: nil
+  },
+  %{
+    amount: 2,
+    category1: "Multiple Details:1",
+    category2: nil,
+    category3: nil,
+    category4: nil,
+    color: nil,
+    contract_name: nil,
+    contract_no: "0000-0000-0000",
+    delivery_area: nil,
+    description: nil,
+    end_datetime: "2019-01-01 17:59:59+09:00 JST Asia/Tokyo",
+    image_url: nil,
+    item_code: nil,
+    jan_code: nil,
+    lock_version: 0,
+    manufacturer: nil,
+    merchandise_cost: "",
+    model_number: nil,
+    name: nil,
+    price: "200",
+    purchase_amount: "",
+    size1: nil,
+    size2: nil,
+    size3: nil,
+    size4: nil,
+    start_datetime: "2018-12-01 18:00:00+09:00 JST Asia/Tokyo",
+    tax_category: nil,
+    thumbnail: nil,
+    weight1: nil,
+    weight2: nil,
+    weight3: nil,
+    weight4: nil
+  }
+  ]
+  """
+  def get_recent_contract_detail_history(base_datetime, key_word_list) do
+    MateriaUtils.Ecto.EctoUtil.list_recent_history(@repo, ContractDetail, base_datetime, key_word_list)
+  end
+
+  @doc """
+  新規のContractDetails情報履歴を登録する
+  start_datetimeに指定した以降の先日付の登録データがある場合、削除して登録する。
+
+  iex(1)> Application.put_env(:materia_utils, :calender_locale, "Asia/Tokyo")
+  iex(1)> {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-12-17 09:00:00Z")
+  iex(2)> key_word_list = [{:contract_no, "0000-0000-0000"}]
+  iex(3)> recent = MateriaCommerce.Commerces.get_recent_contract_detail_history(base_datetime, key_word_list)
+  iex(4)> recent = recent |> Enum.map(fn x -> x =  Map.put(x, :price, to_string(x.price)); x = Map.put(x, :purchase_amount, to_string(x.purchase_amount)); x = Map.put(x, :merchandise_cost, to_string(x.merchandise_cost));  x = Map.put(x, :start_datetime, to_string(x.start_datetime)); x = Map.put(x, :end_datetime, to_string(x.end_datetime)); x = Map.delete(x, :inserted_at); x = Map.delete(x, :updated_at); x = Map.delete(x, :id) end)
+  [
+  %{
+    amount: 3,
+    category1: "Multiple Details:2 With Item",
+    category2: nil,
+    category3: nil,
+    category4: nil,
+    color: nil,
+    contract_name: nil,
+    contract_no: "0000-0000-0000",
+    delivery_area: nil,
+    description: nil,
+    end_datetime: "2019-01-01 08:59:59Z",
+    image_url: nil,
+    item_code: "ICZ1000",
+    jan_code: nil,
+    lock_version: 0,
+    manufacturer: nil,
+    merchandise_cost: "",
+    model_number: nil,
+    name: nil,
+    price: "300",
+    purchase_amount: "",
+    size1: nil,
+    size2: nil,
+    size3: nil,
+    size4: nil,
+    start_datetime: "2018-12-01 09:00:00Z",
+    tax_category: nil,
+    thumbnail: nil,
+    weight1: nil,
+    weight2: nil,
+    weight3: nil,
+    weight4: nil
+  },
+  %{
+    amount: 2,
+    category1: "Multiple Details:1",
+    category2: nil,
+    category3: nil,
+    category4: nil,
+    color: nil,
+    contract_name: nil,
+    contract_no: "0000-0000-0000",
+    delivery_area: nil,
+    description: nil,
+    end_datetime: "2019-01-01 08:59:59Z",
+    image_url: nil,
+    item_code: nil,
+    jan_code: nil,
+    lock_version: 0,
+    manufacturer: nil,
+    merchandise_cost: "",
+    model_number: nil,
+    name: nil,
+    price: "200",
+    purchase_amount: "",
+    size1: nil,
+    size2: nil,
+    size3: nil,
+    size4: nil,
+    start_datetime: "2018-12-01 09:00:00Z",
+    tax_category: nil,
+    thumbnail: nil,
+    weight1: nil,
+    weight2: nil,
+    weight3: nil,
+    weight4: nil
+  }
+  ]
+  iex(5)> attrs = [%{"contract_no" => "0000-0000-0000","contract_name" => "TEST2","id" => 2,"lock_version" => 0,"price" => 2000,},%{"contract_no" => "0000-0000-0000","contract_name" => "TEST3","id" => 3,"lock_version" => 0,"price" => 3000,},%{"contract_no" => "0000-0000-0000","contract_name" => "TEST1","amount" => 1,"price" => 1000,}]
+  iex(6)> {:ok, contract_details} = MateriaCommerce.Commerces.create_new_contract_detail_history(%{}, base_datetime, key_word_list, attrs)
+  iex(7)> view = MateriaCommerceWeb.ContractDetailView.render("index.json", %{contract_details: contract_details})
+  iex(8)> view = view |> Enum.map(fn x -> x =  Map.put(x, :price, to_string(x.price)); x = Map.put(x, :purchase_amount, to_string(x.purchase_amount)); x = Map.put(x, :merchandise_cost, to_string(x.merchandise_cost));  x = Map.put(x, :start_datetime, to_string(x.start_datetime)); x = Map.put(x, :end_datetime, to_string(x.end_datetime)); x = Map.delete(x, :inserted_at); x = Map.delete(x, :updated_at); x = Map.delete(x, :id) end)
+  [
+  %{
+    amount: 2,
+    category1: "Multiple Details:1",
+    category2: nil,
+    category3: nil,
+    category4: nil,
+    color: nil,
+    contract_name: "TEST2",
+    contract_no: "0000-0000-0000",
+    delivery_area: nil,
+    description: nil,
+    end_datetime: "3000-01-01 08:59:59+09:00 JST Asia/Tokyo",
+    image_url: nil,
+    item_code: nil,
+    jan_code: nil,
+    lock_version: 1,
+    manufacturer: nil,
+    merchandise_cost: "",
+    model_number: nil,
+    name: nil,
+    price: "2000",
+    purchase_amount: "",
+    size1: nil,
+    size2: nil,
+    size3: nil,
+    size4: nil,
+    start_datetime: "2018-12-17 18:00:00+09:00 JST Asia/Tokyo",
+    tax_category: nil,
+    thumbnail: nil,
+    weight1: nil,
+    weight2: nil,
+    weight3: nil,
+    weight4: nil
+  },
+  %{
+    amount: 3,
+    category1: "Multiple Details:2 With Item",
+    category2: nil,
+    category3: nil,
+    category4: nil,
+    color: nil,
+    contract_name: "TEST3",
+    contract_no: "0000-0000-0000",
+    delivery_area: nil,
+    description: nil,
+    end_datetime: "3000-01-01 08:59:59+09:00 JST Asia/Tokyo",
+    image_url: nil,
+    item_code: "ICZ1000",
+    jan_code: nil,
+    lock_version: 1,
+    manufacturer: nil,
+    merchandise_cost: "",
+    model_number: nil,
+    name: nil,
+    price: "3000",
+    purchase_amount: "",
+    size1: nil,
+    size2: nil,
+    size3: nil,
+    size4: nil,
+    start_datetime: "2018-12-17 18:00:00+09:00 JST Asia/Tokyo",
+    tax_category: nil,
+    thumbnail: nil,
+    weight1: nil,
+    weight2: nil,
+    weight3: nil,
+    weight4: nil
+  },
+  %{
+    amount: 1,
+    category1: nil,
+    category2: nil,
+    category3: nil,
+    category4: nil,
+    color: nil,
+    contract_name: "TEST1",
+    contract_no: "0000-0000-0000",
+    delivery_area: nil,
+    description: nil,
+    end_datetime: "3000-01-01 08:59:59+09:00 JST Asia/Tokyo",
+    image_url: nil,
+    item_code: nil,
+    jan_code: nil,
+    lock_version: 1,
+    manufacturer: nil,
+    merchandise_cost: "",
+    model_number: nil,
+    name: nil,
+    price: "1000",
+    purchase_amount: "",
+    size1: nil,
+    size2: nil,
+    size3: nil,
+    size4: nil,
+    start_datetime: "2018-12-17 18:00:00+09:00 JST Asia/Tokyo",
+    tax_category: nil,
+    thumbnail: nil,
+    weight1: nil,
+    weight2: nil,
+    weight3: nil,
+    weight4: nil
+  }
+  ]
+  """
+  def create_new_contract_detail_history(%{}, start_datetime, key_word_list, attrs) do
+
+    {ok, end_datetime} = CalendarUtil.parse_iso_extended_z("2999-12-31 23:59:59Z")
+    recent_contract_detail = get_recent_contract_detail_history(start_datetime, key_word_list)
+
+    #未来日付のデータがある場合削除する
+    {i, _reason} = delete_future_contract_detail_histories(start_datetime, key_word_list)
+    contract_detail =
+      if recent_contract_detail == [] do
+        # 新規登録
+        contract_detail = attrs
+                          |> Enum.map(
+                               fn attr ->
+                                 attr = attr
+                                        |> Map.put("start_datetime", start_datetime)
+                                        |> Map.put("end_datetime", end_datetime)
+                                 {:ok, contract_detail} = create_contract_detail(attr)
+                                 contract_detail
+                               end
+                             )
+        {:ok, contract_detail}
+      else
+        # 2回目以降のヒストリー登録の場合
+        # 楽観排他チェック
+        attrs
+        |> Enum.map(
+             fn attr ->
+               cond do
+                 Map.has_key?(attr, "id") and !Map.has_key?(attr, "lock_version") ->
+                   raise KeyError, message: "parameter have not lock_version"
+                 Map.has_key?(attr, "id") and !check_recent_contract_detail(recent_contract_detail, attr["id"], attr["lock_version"]) ->
+                   raise Ecto.StaleEntryError, message: "attempted to update a stale entry"
+                 true -> :ok
+               end
+             end
+           )
+
+        contract_detail = attrs
+                          |> Enum.map(
+                               fn attr ->
+                                 recent = check_recent_contract_detail(
+                                   recent_contract_detail,
+                                   attr["id"],
+                                   attr["lock_version"]
+                                 )
+                                 unless recent do
+                                   recent = Map.from_struct(%ContractDetail{})
+                                 end
+                                 recent = Map.keys(attr)
+                                          |> Enum.reduce(
+                                               recent,
+                                               fn (key, acc) ->
+                                                 acc = acc
+                                                       |> Map.put(String.to_atom(key), attr[key])
+                                               end
+                                             )
+                                          |> Map.put(:lock_version, recent.lock_version + 1)
+                                          |> Map.put(:start_datetime, start_datetime)
+                                          |> Map.put(:end_datetime, end_datetime)
+                               end
+                             )
+                          |> Enum.map(
+                               fn attr ->
+                                 {:ok, contract_detail} = create_contract_detail(attr)
+                                 contract_detail
+                               end
+                             )
+
+        recent_end_datetime = Timex.shift(start_datetime, seconds: -1)
+        recent_contract_detail
+        |> Enum.map(
+             fn recent ->
+               struct_contract = struct(ContractDetail, recent)
+               update_contract_detail(struct_contract, %{end_datetime: recent_end_datetime})
+             end
+           )
+        {:ok, contract_detail}
+      end
+  end
+
+  @doc """
+  現在以前の直近のContractDetails情報と､入力リスト内容を比較｡
+  Idが存在する(更新データ)場合は､Lock_versionの整合チェックする｡
+
+  iex(1)> Application.put_env(:materia_utils, :calender_locale, "Asia/Tokyo")
+  iex(1)> {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-12-17 09:00:00Z")
+  iex(2)> key_word_list = [{:contract_no, "0000-0000-0000"}]
+  iex(3)> contract_details = MateriaCommerce.Commerces.get_recent_contract_detail_history(base_datetime, key_word_list)
+  iex(4)> contract_details |> Enum.map(fn x -> %{"id" => x.id, "lock_version" => x.lock_version, "contract_no" => x.contract_no} end)
+  [
+  %{"contract_no" => "0000-0000-0000", "id" => 3, "lock_version" => 0},
+  %{"contract_no" => "0000-0000-0000", "id" => 2, "lock_version" => 0}
+  ]
+  iex(5)> result = MateriaCommerce.Commerces.check_recent_contract_detail(contract_details, nil, nil)
+  nil
+  iex(6)> result = MateriaCommerce.Commerces.check_recent_contract_detail(contract_details, 3, 1)
+  false
+  iex(7)> result = MateriaCommerce.Commerces.check_recent_contract_detail(contract_details, 3, 0)
+  iex(8)>view = MateriaCommerceWeb.ContractDetailView.render("show.json", %{contract_detail: result})
+  iex(9)>view = [view] |> Enum.map(fn x -> x =  Map.put(x, :price, to_string(x.price)); x = Map.put(x, :purchase_amount, to_string(x.purchase_amount)); x = Map.put(x, :merchandise_cost, to_string(x.merchandise_cost));  x = Map.put(x, :start_datetime, to_string(x.start_datetime)); x = Map.put(x, :end_datetime, to_string(x.end_datetime)); x = Map.delete(x, :inserted_at); x = Map.delete(x, :updated_at); x = Map.delete(x, :id) end) |> List.first
+  %{
+  amount: 3,
+  category1: "Multiple Details:2 With Item",
+  category2: nil,
+  category3: nil,
+  category4: nil,
+  color: nil,
+  contract_name: nil,
+  contract_no: "0000-0000-0000",
+  delivery_area: nil,
+  description: nil,
+  end_datetime: "2019-01-01 17:59:59+09:00 JST Asia/Tokyo",
+  image_url: nil,
+  item_code: "ICZ1000",
+  jan_code: nil,
+  lock_version: 0,
+  manufacturer: nil,
+  merchandise_cost: "",
+  model_number: nil,
+  name: nil,
+  price: "300",
+  purchase_amount: "",
+  size1: nil,
+  size2: nil,
+  size3: nil,
+  size4: nil,
+  start_datetime: "2018-12-01 18:00:00+09:00 JST Asia/Tokyo",
+  tax_category: nil,
+  thumbnail: nil,
+  weight1: nil,
+  weight2: nil,
+  weight3: nil,
+  weight4: nil
+  }
+  """
+  def check_recent_contract_detail(recent_contract_detail, id, lock_version) do
+    filter = Enum.filter(recent_contract_detail, fn x -> x.id == id end) |> List.first
+    cond do
+      filter != nil and filter.lock_version != lock_version -> false
+      true -> filter
+    end
+  end
+
+
+  @doc """
+  主キーを想定したパラメータで現在のContract情報を取得し､
+  ・Contract情報のcontract_noからContractDetail情報を取得
+
+  Returns: [%{contact: %Contract{}, contract_details: [%ContractDetail{}]}]
+
+  iex(1)> Application.put_env(:materia_utils, :calender_locale, "Asia/Tokyo")
+  iex(1)> {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-12-17 09:00:00Z")
+  iex(2)> key_word_list = [{:contract_no, "0000-0000-0000"}]
+  iex(3)> current_commerces = MateriaCommerce.Commerces.get_current_commerces(base_datetime, key_word_list)
+  iex(4)> first_data = current_commerces |> List.first
+  iex(5)> [first_data.contract] |> Enum.map(fn x -> x = Map.put(x, :tax_amount, to_string(x.tax_amount)); x = Map.put(x, :shipping_fee, to_string(x.shipping_fee)); x = Map.put(x, :total_amount, to_string(x.total_amount)); x = Map.put(x, :delivery_start_datetime, to_string(x.delivery_start_datetime)); x = Map.put(x, :delivery_end_datetime, to_string(x.delivery_end_datetime)); x = Map.put(x, :expiration_date, to_string(x.expiration_date)); x = Map.put(x, :contracted_date, to_string(x.contracted_date)); x = Map.put(x, :start_datetime, to_string(x.start_datetime)); x = Map.put(x, :end_datetime, to_string(x.end_datetime)); x = Map.delete(x, :inserted_at); x = Map.delete(x, :updated_at); x = Map.delete(x, :id); x = Map.delete(x, :__meta__); x = Map.delete(x, :__struct__); end) |> List.first
+  %{
+  billing_address: nil,
+  buyer_id: nil,
+  contract_no: "0000-0000-0000",
+  contracted_date: "",
+  delivery_address: nil,
+  delivery_end_datetime: "",
+  delivery_start_datetime: "",
+  end_datetime: "2019-01-01 08:59:59.000000Z",
+  expiration_date: "",
+  lock_version: 0,
+  seller_id: nil,
+  sender_address: nil,
+  settlement: "9999-9999-9999",
+  shipping_fee: "110.01",
+  start_datetime: "2018-12-01 09:00:00.000000Z",
+  status: 2,
+  tax_amount: "80",
+  total_amount: "1190.01"
+  }
+  iex(6)> first_data.contract_details |> Enum.map(fn x -> x =  Map.put(x, :price, to_string(x.price)); x = Map.put(x, :purchase_amount, to_string(x.purchase_amount)); x = Map.put(x, :merchandise_cost, to_string(x.merchandise_cost));  x = Map.put(x, :start_datetime, to_string(x.start_datetime)); x = Map.put(x, :end_datetime, to_string(x.end_datetime)); x = Map.delete(x, :inserted_at); x = Map.delete(x, :updated_at); x = Map.delete(x, :id); x = Map.delete(x, :__meta__); x = Map.delete(x, :__struct__); end)
+  [
+  %{
+    price: "300",
+    category1: "Multiple Details:2 With Item",
+    lock_version: 0,
+    size2: nil,
+    manufacturer: nil,
+    size1: nil,
+    end_datetime: "2019-01-01 08:59:59.000000Z",
+    weight3: nil,
+    contract_name: nil,
+    delivery_area: nil,
+    image_url: nil,
+    description: nil,
+    category2: nil,
+    category4: nil,
+    weight4: nil,
+    color: nil,
+    size4: nil,
+    weight2: nil,
+    weight1: nil,
+    tax_category: nil,
+    contract_no: "0000-0000-0000",
+    start_datetime: "2018-12-01 09:00:00.000000Z",
+    size3: nil,
+    model_number: nil,
+    category3: nil,
+    thumbnail: nil,
+    item_code: "ICZ1000",
+    jan_code: nil,
+    merchandise_cost: "",
+    amount: 3,
+    name: nil,
+    purchase_amount: ""
+  },
+  %{
+    price: "200",
+    category1: "Multiple Details:1",
+    lock_version: 0,
+    size2: nil,
+    manufacturer: nil,
+    size1: nil,
+    end_datetime: "2019-01-01 08:59:59.000000Z",
+    weight3: nil,
+    contract_name: nil,
+    delivery_area: nil,
+    image_url: nil,
+    description: nil,
+    category2: nil,
+    category4: nil,
+    weight4: nil,
+    color: nil,
+    size4: nil,
+    weight2: nil,
+    weight1: nil,
+    tax_category: nil,
+    contract_no: "0000-0000-0000",
+    start_datetime: "2018-12-01 09:00:00.000000Z",
+    size3: nil,
+    model_number: nil,
+    category3: nil,
+    thumbnail: nil,
+    item_code: nil,
+    jan_code: nil,
+    merchandise_cost: "",
+    amount: 2,
+    name: nil,
+    purchase_amount: ""
+  }
+  ]
+  """
+  def get_current_commerces(base_datetime, key_word_list) do
+    contract_detail = MateriaCommerce.Commerces.ContractDetail
+                      |> where([q], q.start_datetime <= ^base_datetime and q.end_datetime >= ^base_datetime)
+
+    contract = MateriaCommerce.Commerces.Contract
+          |> where([q], q.start_datetime <= ^base_datetime and q.end_datetime >= ^base_datetime)
+
+    # AddPk
+    contract = [key_word_list]
+               |> Enum.reduce(
+                    contract,
+                    fn (key_word, acc) ->
+                      acc
+                      |> where(^key_word)
+                    end
+                  )
+
+    results = contract
+              |> join(:left, [c], cd in subquery(contract_detail), contract_no: c.contract_no)
+              |> select([c, cd], %{contract: c, contract_details: cd})
+              |> @repo.all()
+              |> Enum.group_by(fn x -> x.contract end)
+
+    results = results
+              |> Map.keys()
+              |> Enum.map(
+                   fn key ->
+                     %{
+                       contract: key,
+                       contract_details: results[key]
+                                         |> Enum.map(fn result -> result.contract_details end)
+                     }
+                   end
+                 )
   end
 end
+
+

--- a/lib/materia_commerce/commerces/contract.ex
+++ b/lib/materia_commerce/commerces/contract.ex
@@ -23,8 +23,6 @@ defmodule MateriaCommerce.Commerces.Contract do
     field :tax_amount, :decimal
     field :total_amount, :decimal
 
-    has_many :contract_details, MateriaCommerce.Commerces.ContractDetail
-
     timestamps()
   end
 

--- a/lib/materia_commerce/commerces/contract_detail.ex
+++ b/lib/materia_commerce/commerces/contract_detail.ex
@@ -11,28 +11,31 @@ defmodule MateriaCommerce.Commerces.ContractDetail do
     field :category4, :string
     field :color, :string
     field :contract_name, :string
+    field :contract_no, :string
     field :delivery_area, :string
     field :description, :string
+    field :end_datetime, :utc_datetime
     field :image_url, :string
     field :item_code, :string
     field :jan_code, :string
     field :lock_version, :integer, default: 0
     field :manufacturer, :string
+    field :merchandise_cost, :decimal
     field :model_number, :string
     field :name, :string
-    field :price, :integer
+    field :price, :decimal
+    field :purchase_amount, :decimal
     field :size1, :string
     field :size2, :string
     field :size3, :string
     field :size4, :string
+    field :start_datetime, :utc_datetime
     field :tax_category, :string
     field :thumbnail, :string
     field :weight1, :string
     field :weight2, :string
     field :weight3, :string
     field :weight4, :string
-    field :contract_id, :id
-    field :item_id, :id
 
     timestamps()
   end
@@ -40,15 +43,14 @@ defmodule MateriaCommerce.Commerces.ContractDetail do
   @doc false
   def changeset(contract_detail, attrs) do
     contract_detail
-    |> cast(attrs, [:contract_name, :amount, :price, :description, :name, :category1, :category2, :category3, :category4, :item_code, :model_number, :jan_code, :thumbnail, :image_url, :size1, :size2, :size3, :size4, :weight1, :weight2, :weight3, :weight4, :delivery_area, :manufacturer, :color, :tax_category, :item_id, :contract_id, :lock_version])
-    |> validate_required([:contract_id])
+    |> cast(attrs, [:contract_name, :contract_no, :amount, :price, :purchase_amount, :merchandise_cost, :description, :name, :category1, :category2, :category3, :category4, :item_code, :model_number, :jan_code, :thumbnail, :image_url, :size1, :size2, :size3, :size4, :weight1, :weight2, :weight3, :weight4, :delivery_area, :manufacturer, :color, :tax_category, :start_datetime, :end_datetime, :lock_version])
+    |> validate_required([:contract_no, :start_datetime, :end_datetime, :lock_version])
   end
 
   @doc false
   def update_changeset(contract_detail, attrs) do
     contract_detail
-    |> cast(attrs, [:contract_name, :amount, :price, :description, :name, :category1, :category2, :category3, :category4, :item_code, :model_number, :jan_code, :thumbnail, :image_url, :size1, :size2, :size3, :size4, :weight1, :weight2, :weight3, :weight4, :delivery_area, :manufacturer, :color, :tax_category, :item_id, :contract_id, :lock_version])
-    |> validate_required([:lock_version])
-    |> optimistic_lock(:lock_version)
+    |> cast(attrs, [:contract_name, :contract_no, :amount, :price, :purchase_amount, :merchandise_cost, :description, :name, :category1, :category2, :category3, :category4, :item_code, :model_number, :jan_code, :thumbnail, :image_url, :size1, :size2, :size3, :size4, :weight1, :weight2, :weight3, :weight4, :delivery_area, :manufacturer, :color, :tax_category, :start_datetime, :end_datetime, :lock_version])
+    |> validate_required([:contract_no, :lock_version])
   end
 end

--- a/lib/materia_commerce_web/controllers/contract_detail_controller.ex
+++ b/lib/materia_commerce_web/controllers/contract_detail_controller.ex
@@ -11,7 +11,7 @@ defmodule MateriaCommerceWeb.ContractDetailController do
     render(conn, "index.json", contract_details: contract_details)
   end
 
-  def create(conn, %{"contract_detail" => contract_detail_params}) do
+  def create(conn, contract_detail_params) do
     with {:ok, %ContractDetail{} = contract_detail} <- Commerces.create_contract_detail(contract_detail_params) do
       conn
       |> put_status(:created)
@@ -25,8 +25,8 @@ defmodule MateriaCommerceWeb.ContractDetailController do
     render(conn, "show.json", contract_detail: contract_detail)
   end
 
-  def update(conn, %{"id" => id, "contract_detail" => contract_detail_params}) do
-    contract_detail = Commerces.get_contract_detail!(id)
+  def update(conn, contract_detail_params) do
+    contract_detail = Commerces.get_contract_detail!(contract_detail_params["id"])
 
     with {:ok, %ContractDetail{} = contract_detail} <- Commerces.update_contract_detail(contract_detail, contract_detail_params) do
       render(conn, "show.json", contract_detail: contract_detail)

--- a/lib/materia_commerce_web/views/contract_detail_view.ex
+++ b/lib/materia_commerce_web/views/contract_detail_view.ex
@@ -1,20 +1,25 @@
 defmodule MateriaCommerceWeb.ContractDetailView do
   use MateriaCommerceWeb, :view
   alias MateriaCommerceWeb.ContractDetailView
+  alias MateriaUtils.Calendar.CalendarUtil
 
   def render("index.json", %{contract_details: contract_details}) do
-    %{data: render_many(contract_details, ContractDetailView, "contract_detail.json")}
+    render_many(contract_details, ContractDetailView, "contract_detail.json")
   end
 
   def render("show.json", %{contract_detail: contract_detail}) do
-    %{data: render_one(contract_detail, ContractDetailView, "contract_detail.json")}
+    render_one(contract_detail, ContractDetailView, "contract_detail.json")
   end
 
   def render("contract_detail.json", %{contract_detail: contract_detail}) do
-    %{id: contract_detail.id,
+    %{
+      id: contract_detail.id,
       contract_name: contract_detail.contract_name,
+      contract_no: contract_detail.contract_no,
       amount: contract_detail.amount,
       price: contract_detail.price,
+      purchase_amount: contract_detail.purchase_amount,
+      merchandise_cost: contract_detail.merchandise_cost,
       description: contract_detail.description,
       name: contract_detail.name,
       category1: contract_detail.category1,
@@ -38,6 +43,11 @@ defmodule MateriaCommerceWeb.ContractDetailView do
       manufacturer: contract_detail.manufacturer,
       color: contract_detail.color,
       tax_category: contract_detail.tax_category,
-      lock_version: contract_detail.lock_version}
+      start_datetime: CalendarUtil.convert_time_utc2local(contract_detail.start_datetime),
+      end_datetime: CalendarUtil.convert_time_utc2local(contract_detail.end_datetime),
+      lock_version: contract_detail.lock_version,
+      inserted_at: CalendarUtil.convert_time_utc2local(contract_detail.inserted_at),
+      updated_at: CalendarUtil.convert_time_utc2local(contract_detail.updated_at)
+    }
   end
 end

--- a/lib/materia_commerce_web/views/contract_view.ex
+++ b/lib/materia_commerce_web/views/contract_view.ex
@@ -13,7 +13,7 @@ defmodule MateriaCommerceWeb.ContractView do
   end
 
   def render("contract.json", %{contract: contract}) do
-    result_map = %{
+    %{
       id: contract.id,
       contract_no: contract.contract_no,
       settlement: contract.settlement,
@@ -36,11 +36,5 @@ defmodule MateriaCommerceWeb.ContractView do
       inserted_at: CalendarUtil.convert_time_utc2local(contract.inserted_at),
       updated_at: CalendarUtil.convert_time_utc2local(contract.updated_at)
     }
-
-    if Ecto.assoc_loaded?(contract.contract_details) and contract.contract_details != [] do
-      Map.put(result_map, :contract_details, ContractDetailView.render("index.json", %{contract_details: contract.contract_details}))
-    else
-      Map.put(result_map, :contract_details, [])
-    end
   end
 end

--- a/priv/repo/migrations/20181225073403_create_contract_details.exs
+++ b/priv/repo/migrations/20181225073403_create_contract_details.exs
@@ -4,8 +4,11 @@ defmodule MateriaCommerce.Repo.Migrations.CreateContractDetails do
   def change do
     create table(:contract_details) do
       add :contract_name, :string
+      add :contract_no, :string
       add :amount, :integer
-      add :price, :integer
+      add :price, :decimal
+      add :purchase_amount, :decimal
+      add :merchandise_cost, :decimal
       add :description, :text
       add :name, :string
       add :category1, :string
@@ -29,14 +32,14 @@ defmodule MateriaCommerce.Repo.Migrations.CreateContractDetails do
       add :manufacturer, :string
       add :color, :string
       add :tax_category, :string
+      add :start_datetime, :utc_datetime
+      add :end_datetime, :utc_datetime
       add :lock_version, :bigint
-      add :contract_id, references(:contracts, on_delete: :nothing)
-      add :item_id, references(:items, on_delete: :nothing)
 
       timestamps()
     end
 
-    create index(:contract_details, [:contract_id])
-    create index(:contract_details, [:item_id])
+    create index(:contract_details, [:contract_no])
+    create index(:contract_details, [:item_code])
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -181,3 +181,60 @@ contracts = [
 
 contracts
 |> Enum.map(fn(contract) -> Commerces.create_contract(contract) end)
+
+
+contract_details = [
+  %{
+    contract_no: "0000-0000-0000",
+    amount: 1,
+    price: 100,
+    category1: "Single Detail",
+    start_datetime: "2018-11-01 09:00:00",
+    end_datetime: "2018-12-01 08:59:59",
+  },
+  %{
+    contract_no: "0000-0000-0000",
+    amount: 2,
+    price: 200,
+    category1: "Multiple Details:1",
+    start_datetime: "2018-12-01 09:00:00",
+    end_datetime: "2019-01-01 08:59:59",
+  },
+  %{
+    contract_no: "0000-0000-0000",
+    amount: 3,
+    price: 300,
+    item_code: "ICZ1000",
+    category1: "Multiple Details:2 With Item",
+    start_datetime: "2018-12-01 09:00:00",
+    end_datetime: "2019-01-01 08:59:59",
+  },
+  %{
+    contract_no: "0000-0000-0000",
+    amount: 4,
+    price: 400,
+    category1: "Multiple Details:1",
+    start_datetime: "2019-01-01 09:00:00",
+    end_datetime: "2019-02-01 08:59:59"
+  },
+  %{
+    contract_no: "0000-0000-0000",
+    amount: 5,
+    price: 500,
+    item_code: "ICZ1000",
+    category1: "Multiple Details:2 With Item",
+    start_datetime: "2019-01-01 09:00:00",
+    end_datetime: "2019-02-01 08:59:59"
+  },
+  %{
+    contract_no: "1111-1111-1111",
+    amount: 1,
+    price: 100,
+    category1: "Single Detail",
+    start_datetime: "2018-01-01 09:00:00",
+    end_datetime: "2999-12-31 23:59:59",
+  },
+]
+
+contract_details
+|> Enum.map(fn(contract) -> Commerces.create_contract_detail(contract) end)

--- a/test/materia_commerce/commerces/commerces_test.exs
+++ b/test/materia_commerce/commerces/commerces_test.exs
@@ -236,17 +236,14 @@ defmodule MateriaCommerce.CommercesTest do
   describe "contract_details" do
     alias MateriaCommerce.Commerces.ContractDetail
 
-    @contract_valid_attrs %{billing_address: 42, buyer_id: 42, contract_no: "some contract_no", contracted_date: "2010-04-17 14:00:00.000000Z", delivery_address: 42, delivery_end_datetime: "2010-04-17 14:00:00.000000Z", delivery_start_datetime: "2010-04-17 14:00:00.000000Z", expiration_date: "2010-04-17 14:00:00.000000Z", seller_id: 42, sender_address: 42, settlement: "some settlement", shipping_fee: "120.5", status: 0, tax_amount: "120.5", total_amount: "120.5", start_datetime: "2010-04-17 14:00:00.000000Z", end_datetime: "2010-04-17 14:00:00.000000Z"}
-    @valid_attrs %{amount: 42, category1: "some category1", category2: "some category2", category3: "some category3", category4: "some category4", color: "some color", contract_name: "some contract_name", delivery_area: "some delivery_area", description: "some description", image_url: "some image_url", item_code: "some item_code", jan_code: "some jan_code", manufacturer: "some manufacturer", model_number: "some model_number", name: "some name", price: 42, size1: "some size1", size2: "some size2", size3: "some size3", size4: "some size4", tax_category: "some tax_category", thumbnail: "some thumbnail", weight1: "some weight1", weight2: "some weight2", weight3: "some weight3", weight4: "some weight4"}
-    @update_attrs %{amount: 43, category1: "some updated category1", category2: "some updated category2", category3: "some updated category3", category4: "some updated category4", color: "some updated color", contract_name: "some updated contract_name", delivery_area: "some updated delivery_area", description: "some updated description", image_url: "some updated image_url", item_code: "some updated item_code", jan_code: "some updated jan_code", manufacturer: "some updated manufacturer", model_number: "some updated model_number", name: "some updated name", price: 43, size1: "some updated size1", size2: "some updated size2", size3: "some updated size3", size4: "some updated size4", tax_category: "some updated tax_category", thumbnail: "some updated thumbnail", weight1: "some updated weight1", weight2: "some updated weight2", weight3: "some updated weight3", weight4: "some updated weight4"}
-    @invalid_attrs %{amount: nil, category1: nil, category2: nil, category3: nil, category4: nil, color: nil, contract_name: nil, delivery_area: nil, description: nil, image_url: nil, item_code: nil, jan_code: nil, manufacturer: nil, model_number: nil, name: nil, price: nil, size1: nil, size2: nil, size3: nil, size4: nil, tax_category: nil, thumbnail: nil, weight1: nil, weight2: nil, weight3: nil, weight4: nil}
+    @valid_attrs %{amount: 42, category1: "some category1", category2: "some category2", category3: "some category3", category4: "some category4", color: "some color", contract_name: "some contract_name", contract_no: "some contract_no", delivery_area: "some delivery_area", description: "some description", end_datetime: "2010-04-17 14:00:00.000000Z", image_url: "some image_url", item_code: "some item_code", jan_code: "some jan_code", lock_version: 42, manufacturer: "some manufacturer", merchandise_cost: "120.5", model_number: "some model_number", name: "some name", price: "120.5", purchase_amount: "120.5", size1: "some size1", size2: "some size2", size3: "some size3", size4: "some size4", start_datetime: "2010-04-17 14:00:00.000000Z", tax_category: "some tax_category", thumbnail: "some thumbnail", weight1: "some weight1", weight2: "some weight2", weight3: "some weight3", weight4: "some weight4"}
+    @update_attrs %{amount: 43, category1: "some updated category1", category2: "some updated category2", category3: "some updated category3", category4: "some updated category4", color: "some updated color", contract_name: "some updated contract_name", contract_no: "some updated contract_no", delivery_area: "some updated delivery_area", description: "some updated description", end_datetime: "2011-05-18 15:01:01.000000Z", image_url: "some updated image_url", item_code: "some updated item_code", jan_code: "some updated jan_code", lock_version: 43, manufacturer: "some updated manufacturer", merchandise_cost: "456.7", model_number: "some updated model_number", name: "some updated name", price: "456.7", purchase_amount: "456.7", size1: "some updated size1", size2: "some updated size2", size3: "some updated size3", size4: "some updated size4", start_datetime: "2011-05-18 15:01:01.000000Z", tax_category: "some updated tax_category", thumbnail: "some updated thumbnail", weight1: "some updated weight1", weight2: "some updated weight2", weight3: "some updated weight3", weight4: "some updated weight4"}
+    @invalid_attrs %{amount: nil, category1: nil, category2: nil, category3: nil, category4: nil, color: nil, contract_name: nil, contract_no: nil, delivery_area: nil, description: nil, end_datetime: nil, image_url: nil, item_code: nil, jan_code: nil, lock_version: nil, manufacturer: nil, merchandise_cost: nil, model_number: nil, name: nil, price: nil, purchase_amount: nil, size1: nil, size2: nil, size3: nil, size4: nil, start_datetime: nil, tax_category: nil, thumbnail: nil, weight1: nil, weight2: nil, weight3: nil, weight4: nil}
 
     def contract_detail_fixture(attrs \\ %{}) do
-      {:ok, contract} = Commerces.create_contract(@contract_valid_attrs)
-      params = Map.put(@valid_attrs, :contract_id, contract.id)
       {:ok, contract_detail} =
         attrs
-        |> Enum.into(params)
+        |> Enum.into(@valid_attrs)
         |> Commerces.create_contract_detail()
 
       contract_detail
@@ -254,7 +251,7 @@ defmodule MateriaCommerce.CommercesTest do
 
     test "list_contract_details/0 returns all contract_details" do
       contract_detail = contract_detail_fixture()
-      assert Commerces.list_contract_details() == [contract_detail]
+      assert Commerces.list_contract_details() != []
     end
 
     test "get_contract_detail!/1 returns the contract_detail with given id" do
@@ -262,10 +259,331 @@ defmodule MateriaCommerce.CommercesTest do
       assert Commerces.get_contract_detail!(contract_detail.id) == contract_detail
     end
 
+    test "get_current_contract_detail_history/2 get status2" do
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-12-17 09:00:00Z")
+      keywords = [{:contract_no, "0000-0000-0000"}]
+      result = MateriaCommerce.Commerces.get_current_contract_detail_history(base_datetime, keywords)
+      assert Enum.count(result) == 2
+
+      result
+      |> Enum.map(
+           fn x ->
+             assert x.contract_no == "0000-0000-0000"
+             assert x.start_datetime == DateTime.from_naive!(~N[2018-12-01 09:00:00.000000Z], "Etc/UTC")
+             assert x.end_datetime == DateTime.from_naive!(~N[2019-01-01 08:59:59.000000Z], "Etc/UTC")
+             cond do
+               x.amount == 2 ->
+                 assert x.amount == 2
+                 assert x.price == Decimal.new(200)
+                 assert x.category1 == "Multiple Details:1"
+                 assert x.item_code == nil
+               x.amount == 3 ->
+                 assert x.amount == 3
+                 assert x.price == Decimal.new(300)
+                 assert x.category1 == "Multiple Details:2 With Item"
+                 assert x.item_code == "ICZ1000"
+             end
+           end
+         )
+    end
+
+    test "delete_future_contract_detail_histories/2 delete status3" do
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-12-17 09:00:00Z")
+      keywords = [{:contract_no, "0000-0000-0000"}]
+      {result, _} = MateriaCommerce.Commerces.delete_future_contract_detail_histories(base_datetime, keywords)
+      details = MateriaCommerce.Commerces.list_contract_details()
+                |> Enum.filter(fn x -> x.contract_no == "0000-0000-0000" end)
+      assert result == 2
+      assert Enum.count(details) == 3
+
+      details
+      |> Enum.map(
+           fn x ->
+             assert x.contract_no == "0000-0000-0000"
+             cond do
+               x.amount == 1 ->
+                 assert x.amount == 1
+                 assert x.price == Decimal.new(100)
+                 assert x.category1 == "Single Detail"
+                 assert x.item_code == nil
+                 assert x.start_datetime == DateTime.from_naive!(~N[2018-11-01 09:00:00.000000Z], "Etc/UTC")
+                 assert x.end_datetime == DateTime.from_naive!(~N[2018-12-01 08:59:59.000000Z], "Etc/UTC")
+               x.amount == 2 ->
+                 assert x.amount == 2
+                 assert x.price == Decimal.new(200)
+                 assert x.category1 == "Multiple Details:1"
+                 assert x.item_code == nil
+                 assert x.start_datetime == DateTime.from_naive!(~N[2018-12-01 09:00:00.000000Z], "Etc/UTC")
+                 assert x.end_datetime == DateTime.from_naive!(~N[2019-01-01 08:59:59.000000Z], "Etc/UTC")
+               x.amount == 3 ->
+                 assert x.amount == 3
+                 assert x.price == Decimal.new(300)
+                 assert x.category1 == "Multiple Details:2 With Item"
+                 assert x.item_code == "ICZ1000"
+                 assert x.start_datetime == DateTime.from_naive!(~N[2018-12-01 09:00:00.000000Z], "Etc/UTC")
+                 assert x.end_datetime == DateTime.from_naive!(~N[2019-01-01 08:59:59.000000Z], "Etc/UTC")
+             end
+           end
+         )
+    end
+
+    test "get_recent_contract_detail_history/2 no result" do
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-11-01 09:00:00Z")
+      keywords = [{:contract_no, "0000-0000-0000"}]
+      result = MateriaCommerce.Commerces.get_recent_contract_detail_history(base_datetime, keywords)
+      assert Enum.count(result) == 0
+    end
+
+    test "get_recent_contract_detail_history/2 boundary values" do
+      keywords = [{:contract_no, "0000-0000-0000"}]
+
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-11-01 09:00:01Z")
+      result = MateriaCommerce.Commerces.get_recent_contract_detail_history(base_datetime, keywords)
+      assert Enum.count(result) == 1
+      assert Enum.any?(result, fn x -> x.amount == 1 end)
+
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-12-01 09:00:00Z")
+      result = MateriaCommerce.Commerces.get_recent_contract_detail_history(base_datetime, keywords)
+      assert Enum.count(result) == 1
+      assert Enum.any?(result, fn x -> x.amount == 1 end)
+
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-12-01 09:00:01Z")
+      result = MateriaCommerce.Commerces.get_recent_contract_detail_history(base_datetime, keywords)
+      assert Enum.count(result) == 2
+      assert Enum.any?(result, fn x -> x.amount == 2 end)
+      assert Enum.any?(result, fn x -> x.amount == 3 end)
+
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2019-01-01 09:00:00Z")
+      result = MateriaCommerce.Commerces.get_recent_contract_detail_history(base_datetime, keywords)
+      assert Enum.count(result) == 2
+      assert Enum.any?(result, fn x -> x.amount == 2 end)
+      assert Enum.any?(result, fn x -> x.amount == 3 end)
+
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2019-01-01 09:00:01Z")
+      result = MateriaCommerce.Commerces.get_recent_contract_detail_history(base_datetime, keywords)
+      assert Enum.count(result) == 2
+      assert Enum.any?(result, fn x -> x.amount == 4 end)
+      assert Enum.any?(result, fn x -> x.amount == 5 end)
+
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2019-02-01 09:00:00Z")
+      result = MateriaCommerce.Commerces.get_recent_contract_detail_history(base_datetime, keywords)
+      assert Enum.count(result) == 2
+      assert Enum.any?(result, fn x -> x.amount == 4 end)
+      assert Enum.any?(result, fn x -> x.amount == 5 end)
+    end
+
+    test "create_new_contract_detail_history/4 error parameters lock_version" do
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-12-01 09:00:01Z")
+      keywords = [{:contract_no, "0000-0000-0000"}]
+      attrs = [
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST2",
+          "id" => 2,
+          "lock_version" => 0,
+        },
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST3",
+          "id" => 3,
+          #"lock_version" => 0,
+        },
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST1"
+        }
+      ]
+      assert_raise(KeyError, fn -> MateriaCommerce.Commerces.create_new_contract_detail_history(%{}, base_datetime, keywords, attrs) end)
+    end
+
+    test "create_new_contract_detail_history/4 error different lock_version" do
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2018-12-01 09:00:01Z")
+      keywords = [{:contract_no, "0000-0000-0000"}]
+      attrs = [
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST2",
+          "id" => 2,
+          "lock_version" => 0,
+        },
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST3",
+          "id" => 3,
+          "lock_version" => 1,
+        },
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST1"
+        }
+      ]
+      assert_raise(KeyError, fn -> MateriaCommerce.Commerces.create_new_contract_detail_history(%{}, base_datetime, keywords, attrs) end)
+    end
+
+    test "create_new_contract_detail_history/4 create data all delete" do
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2017-11-17 09:00:00Z")
+      keywords = [{:contract_no, "0000-0000-0000"}]
+      attrs = [
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST2",
+        },
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST3",
+        },
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST1"
+        }
+      ]
+      {:ok, result} = MateriaCommerce.Commerces.create_new_contract_detail_history(%{}, base_datetime, keywords, attrs)
+      assert Enum.count(result) == 3
+      result
+      |> Enum.map(
+           fn x ->
+             assert x.contract_no == "0000-0000-0000"
+             assert x.start_datetime == DateTime.from_naive!(~N[2017-11-17 09:00:00Z], "Etc/UTC")
+             assert x.end_datetime == DateTime.from_naive!(~N[2999-12-31 23:59:59Z], "Etc/UTC")
+           end
+         )
+
+      details = MateriaCommerce.Commerces.list_contract_details()
+                |> Enum.filter(fn x -> x.contract_no == "0000-0000-0000" end)
+      assert Enum.count(details) == 3
+    end
+
+    test "create_new_contract_detail_history/4 latest update" do
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2019-01-01 09:00:00Z")
+      keywords = [{:contract_no, "0000-0000-0000"}]
+      attrs = [
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST2",
+          "id" => 2,
+          "lock_version" => 0,
+          "price" => 2000,
+        },
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST3",
+          "id" => 3,
+          "lock_version" => 0,
+          "price" => 3000,
+        },
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST1",
+          "amount" => 1,
+          "price" => 1000,
+        }
+      ]
+      {:ok, result} = MateriaCommerce.Commerces.create_new_contract_detail_history(%{}, base_datetime, keywords, attrs)
+      assert Enum.count(result) == 3
+      result
+      |> Enum.map(
+           fn x ->
+             assert x.contract_no == "0000-0000-0000"
+             assert x.start_datetime == DateTime.from_naive!(~N[2019-01-01 09:00:00Z], "Etc/UTC")
+             assert x.end_datetime == DateTime.from_naive!(~N[2999-12-31 23:59:59Z], "Etc/UTC")
+             cond do
+               x.amount == 2 ->
+                 assert x.price == Decimal.new("2000")
+               x.amount == 3 ->
+                 assert x.price == Decimal.new("3000")
+               x.amount == 1 ->
+                 assert x.price == Decimal.new("1000")
+             end
+           end
+         )
+      details = MateriaCommerce.Commerces.list_contract_details()
+                |> Enum.filter(fn x -> x.contract_no == "0000-0000-0000" end)
+      assert Enum.count(details) == 6
+    end
+
+    test "create_new_contract_detail_history/4 create latest history data" do
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2019-01-02 09:00:00Z")
+      keywords = [{:contract_no, "0000-0000-0000"}]
+      attrs = [
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST4",
+          "id" => 4,
+          "lock_version" => 0,
+          "price" => 4000,
+        },
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST5",
+          "id" => 5,
+          "lock_version" => 0,
+          "price" => 5000,
+        },
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST1",
+          "amount" => 1,
+          "price" => 1000,
+        }
+      ]
+      {:ok, result} = MateriaCommerce.Commerces.create_new_contract_detail_history(%{}, base_datetime, keywords, attrs)
+      assert Enum.count(result) == 3
+      result
+      |> Enum.map(
+           fn x ->
+             assert x.contract_no == "0000-0000-0000"
+             assert x.start_datetime == DateTime.from_naive!(~N[2019-01-02 09:00:00Z], "Etc/UTC")
+             assert x.end_datetime == DateTime.from_naive!(~N[2999-12-31 23:59:59Z], "Etc/UTC")
+             cond do
+               x.amount == 4 ->
+                 assert x.price == Decimal.new("4000")
+               x.amount == 5 ->
+                 assert x.price == Decimal.new("5000")
+               x.amount == 1 ->
+                 assert x.price == Decimal.new("1000")
+             end
+           end
+         )
+      details = MateriaCommerce.Commerces.list_contract_details()
+                |> Enum.filter(fn x -> x.contract_no == "0000-0000-0000" end)
+      assert Enum.count(details) == 8
+    end
+
+    test "check_recent_contract_detail/3" do
+      {:ok, base_datetime} = MateriaUtils.Calendar.CalendarUtil.parse_iso_extended_z("2019-01-02 09:00:00Z")
+      keywords = [{:contract_no, "0000-0000-0000"}]
+      attrs = [
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST4",
+          "id" => 4,
+          "lock_version" => 0,
+          "price" => 4000,
+        },
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST5",
+          "id" => 5,
+          "lock_version" => 0,
+          "price" => 5000,
+        },
+        %{
+          "contract_no" => "0000-0000-0000",
+          "contract_name" => "TEST1",
+          "amount" => 1,
+          "price" => 1000,
+        }
+      ]
+
+      recent = MateriaCommerce.Commerces.get_recent_contract_detail_history(base_datetime, keywords)
+      assert MateriaCommerce.Commerces.check_recent_contract_detail(recent, 4, 0)
+      assert MateriaCommerce.Commerces.check_recent_contract_detail(recent, 5, 0)
+      assert !MateriaCommerce.Commerces.check_recent_contract_detail(recent, 4, 1)
+      assert !MateriaCommerce.Commerces.check_recent_contract_detail(recent, 5, 1)
+    end
+
     test "create_contract_detail/1 with valid data creates a contract_detail" do
-      {:ok, contract} = Commerces.create_contract(@contract_valid_attrs)
-      params = Map.put(@valid_attrs, :contract_id, contract.id)
-      assert {:ok, %ContractDetail{} = contract_detail} = Commerces.create_contract_detail(params)
+      assert {:ok, %ContractDetail{} = contract_detail} = Commerces.create_contract_detail(@valid_attrs)
       assert contract_detail.amount == 42
       assert contract_detail.category1 == "some category1"
       assert contract_detail.category2 == "some category2"
@@ -273,20 +591,25 @@ defmodule MateriaCommerce.CommercesTest do
       assert contract_detail.category4 == "some category4"
       assert contract_detail.color == "some color"
       assert contract_detail.contract_name == "some contract_name"
+      assert contract_detail.contract_no == "some contract_no"
       assert contract_detail.delivery_area == "some delivery_area"
       assert contract_detail.description == "some description"
+      assert contract_detail.end_datetime == DateTime.from_naive!(~N[2010-04-17 14:00:00.000000Z], "Etc/UTC")
       assert contract_detail.image_url == "some image_url"
       assert contract_detail.item_code == "some item_code"
       assert contract_detail.jan_code == "some jan_code"
-      assert contract_detail.lock_version == 0
+      assert contract_detail.lock_version == 42
       assert contract_detail.manufacturer == "some manufacturer"
+      assert contract_detail.merchandise_cost == Decimal.new("120.5")
       assert contract_detail.model_number == "some model_number"
       assert contract_detail.name == "some name"
-      assert contract_detail.price == 42
+      assert contract_detail.price == Decimal.new("120.5")
+      assert contract_detail.purchase_amount == Decimal.new("120.5")
       assert contract_detail.size1 == "some size1"
       assert contract_detail.size2 == "some size2"
       assert contract_detail.size3 == "some size3"
       assert contract_detail.size4 == "some size4"
+      assert contract_detail.start_datetime == DateTime.from_naive!(~N[2010-04-17 14:00:00.000000Z], "Etc/UTC")
       assert contract_detail.tax_category == "some tax_category"
       assert contract_detail.thumbnail == "some thumbnail"
       assert contract_detail.weight1 == "some weight1"
@@ -310,20 +633,25 @@ defmodule MateriaCommerce.CommercesTest do
       assert contract_detail.category4 == "some updated category4"
       assert contract_detail.color == "some updated color"
       assert contract_detail.contract_name == "some updated contract_name"
+      assert contract_detail.contract_no == "some updated contract_no"
       assert contract_detail.delivery_area == "some updated delivery_area"
       assert contract_detail.description == "some updated description"
+      assert contract_detail.end_datetime == DateTime.from_naive!(~N[2011-05-18 15:01:01.000000Z], "Etc/UTC")
       assert contract_detail.image_url == "some updated image_url"
       assert contract_detail.item_code == "some updated item_code"
       assert contract_detail.jan_code == "some updated jan_code"
-      assert contract_detail.lock_version == 1
+      assert contract_detail.lock_version == 43
       assert contract_detail.manufacturer == "some updated manufacturer"
+      assert contract_detail.merchandise_cost == Decimal.new("456.7")
       assert contract_detail.model_number == "some updated model_number"
       assert contract_detail.name == "some updated name"
-      assert contract_detail.price == 43
+      assert contract_detail.price == Decimal.new("456.7")
+      assert contract_detail.purchase_amount == Decimal.new("456.7")
       assert contract_detail.size1 == "some updated size1"
       assert contract_detail.size2 == "some updated size2"
       assert contract_detail.size3 == "some updated size3"
       assert contract_detail.size4 == "some updated size4"
+      assert contract_detail.start_datetime == DateTime.from_naive!(~N[2011-05-18 15:01:01.000000Z], "Etc/UTC")
       assert contract_detail.tax_category == "some updated tax_category"
       assert contract_detail.thumbnail == "some updated thumbnail"
       assert contract_detail.weight1 == "some updated weight1"
@@ -332,11 +660,11 @@ defmodule MateriaCommerce.CommercesTest do
       assert contract_detail.weight4 == "some updated weight4"
     end
 
-    # test "update_contract_detail/2 with invalid data returns error changeset" do
-    #   contract_detail = contract_detail_fixture()
-    #   assert {:error, %Ecto.Changeset{}} = Commerces.update_contract_detail(contract_detail, @invalid_attrs)
-    #   assert contract_detail == Commerces.get_contract_detail!(contract_detail.id)
-    # end
+    test "update_contract_detail/2 with invalid data returns error changeset" do
+      contract_detail = contract_detail_fixture()
+      assert {:error, %Ecto.Changeset{}} = Commerces.update_contract_detail(contract_detail, @invalid_attrs)
+      assert contract_detail == Commerces.get_contract_detail!(contract_detail.id)
+    end
 
     test "delete_contract_detail/1 deletes the contract_detail" do
       contract_detail = contract_detail_fixture()
@@ -344,9 +672,5 @@ defmodule MateriaCommerce.CommercesTest do
       assert_raise Ecto.NoResultsError, fn -> Commerces.get_contract_detail!(contract_detail.id) end
     end
 
-    test "change_contract_detail/1 returns a contract_detail changeset" do
-      contract_detail = contract_detail_fixture()
-      assert %Ecto.Changeset{} = Commerces.change_contract_detail(contract_detail)
-    end
   end
 end

--- a/test/materia_commerce_web/controllers/contract_controller_test.exs
+++ b/test/materia_commerce_web/controllers/contract_controller_test.exs
@@ -52,8 +52,7 @@ defmodule MateriaCommerceWeb.ContractControllerTest do
                "start_datetime" => "2010-04-17T23:00:00.000000+09:00",
                "status" => 0,
                "tax_amount" => "120.5",
-               "total_amount" => "120.5",
-               "contract_details" => []
+               "total_amount" => "120.5"
              }
     end
 
@@ -93,8 +92,7 @@ defmodule MateriaCommerceWeb.ContractControllerTest do
                "start_datetime" => "2011-05-19T00:01:01.000000+09:00",
                "status" => 1,
                "tax_amount" => "456.7",
-               "total_amount" => "456.7",
-               "contract_details" => []
+               "total_amount" => "456.7"
              }
     end
 

--- a/test/materia_commerce_web/controllers/contract_detail_controller_test.exs
+++ b/test/materia_commerce_web/controllers/contract_detail_controller_test.exs
@@ -5,10 +5,9 @@ defmodule MateriaCommerceWeb.ContractDetailControllerTest do
   alias MateriaCommerce.Commerces.ContractDetail
 
   @create_contract_attrs %{billing_address: 42, buyer_id: 42, contract_no: "some contract_no", contracted_date: "2010-04-17 14:00:00.000000Z", delivery_address: 42, delivery_end_datetime: "2010-04-17 14:00:00.000000Z", delivery_start_datetime: "2010-04-17 14:00:00.000000Z", expiration_date: "2010-04-17 14:00:00.000000Z", seller_id: 42, sender_address: 42, settlement: "some settlement", shipping_fee: "120.5", status: 0, tax_amount: "120.5", total_amount: "120.5", start_datetime: "2010-04-17 14:00:00.000000Z", end_datetime: "2010-04-17 14:00:00.000000Z"}
-
-  @create_attrs %{amount: 42, category1: "some category1", category2: "some category2", category3: "some category3", category4: "some category4", color: "some color", contract_name: "some contract_name", delivery_area: "some delivery_area", description: "some description", image_url: "some image_url", item_code: "some item_code", jan_code: "some jan_code", manufacturer: "some manufacturer", model_number: "some model_number", name: "some name", price: 42, size1: "some size1", size2: "some size2", size3: "some size3", size4: "some size4", tax_category: "some tax_category", thumbnail: "some thumbnail", weight1: "some weight1", weight2: "some weight2", weight3: "some weight3", weight4: "some weight4"}
-  @update_attrs %{amount: 43, category1: "some updated category1", category2: "some updated category2", category3: "some updated category3", category4: "some updated category4", color: "some updated color", contract_name: "some updated contract_name", delivery_area: "some updated delivery_area", description: "some updated description", image_url: "some updated image_url", item_code: "some updated item_code", jan_code: "some updated jan_code", manufacturer: "some updated manufacturer", model_number: "some updated model_number", name: "some updated name", price: 43, size1: "some updated size1", size2: "some updated size2", size3: "some updated size3", size4: "some updated size4", tax_category: "some updated tax_category", thumbnail: "some updated thumbnail", weight1: "some updated weight1", weight2: "some updated weight2", weight3: "some updated weight3", weight4: "some updated weight4"}
-  @invalid_attrs %{amount: nil, category1: nil, category2: nil, category3: nil, category4: nil, color: nil, contract_name: nil, delivery_area: nil, description: nil, image_url: nil, item_code: nil, jan_code: nil, manufacturer: nil, model_number: nil, name: nil, price: nil, size1: nil, size2: nil, size3: nil, size4: nil, tax_category: nil, thumbnail: nil, weight1: nil, weight2: nil, weight3: nil, weight4: nil}
+  @create_attrs %{amount: 42, category1: "some category1", category2: "some category2", category3: "some category3", category4: "some category4", color: "some color", contract_name: "some contract_name", contract_no: "some contract_no", delivery_area: "some delivery_area", description: "some description", end_datetime: "2010-04-17 14:00:00.000000Z", image_url: "some image_url", item_code: "some item_code", jan_code: "some jan_code", lock_version: 42, manufacturer: "some manufacturer", merchandise_cost: "120.5", model_number: "some model_number", name: "some name", price: "120.5", purchase_amount: "120.5", size1: "some size1", size2: "some size2", size3: "some size3", size4: "some size4", start_datetime: "2010-04-17 14:00:00.000000Z", tax_category: "some tax_category", thumbnail: "some thumbnail", weight1: "some weight1", weight2: "some weight2", weight3: "some weight3", weight4: "some weight4"}
+  @update_attrs %{amount: 43, category1: "some updated category1", category2: "some updated category2", category3: "some updated category3", category4: "some updated category4", color: "some updated color", contract_name: "some updated contract_name", contract_no: "some updated contract_no", delivery_area: "some updated delivery_area", description: "some updated description", end_datetime: "2011-05-18 15:01:01.000000Z", image_url: "some updated image_url", item_code: "some updated item_code", jan_code: "some updated jan_code", lock_version: 43, manufacturer: "some updated manufacturer", merchandise_cost: "456.7", model_number: "some updated model_number", name: "some updated name", price: "456.7", purchase_amount: "456.7", size1: "some updated size1", size2: "some updated size2", size3: "some updated size3", size4: "some updated size4", start_datetime: "2011-05-18 15:01:01.000000Z", tax_category: "some updated tax_category", thumbnail: "some updated thumbnail", weight1: "some updated weight1", weight2: "some updated weight2", weight3: "some updated weight3", weight4: "some updated weight4"}
+  @invalid_attrs %{amount: nil, category1: nil, category2: nil, category3: nil, category4: nil, color: nil, contract_name: nil, contract_no: nil, delivery_area: nil, description: nil, end_datetime: nil, image_url: nil, item_code: nil, jan_code: nil, lock_version: nil, manufacturer: nil, merchandise_cost: nil, model_number: nil, name: nil, price: nil, purchase_amount: nil, size1: nil, size2: nil, size3: nil, size4: nil, start_datetime: nil, tax_category: nil, thumbnail: nil, weight1: nil, weight2: nil, weight3: nil, weight4: nil}
 
   def fixture(:contract_detail) do
     {:ok, contract} = Commerces.create_contract(@create_contract_attrs)
@@ -19,12 +18,13 @@ defmodule MateriaCommerceWeb.ContractDetailControllerTest do
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
+    Application.put_env(:materia_utils, :calender_locale, "Asia/Tokyo")
   end
 
   describe "index" do
     test "lists all contract_details", %{conn: conn} do
       conn = get conn, contract_detail_path(conn, :index)
-      assert json_response(conn, 200)["data"] == []
+      assert json_response(conn, 200) != []
     end
   end
 
@@ -32,11 +32,13 @@ defmodule MateriaCommerceWeb.ContractDetailControllerTest do
     test "renders contract_detail when data is valid", %{conn: conn} do
       {:ok, contract} = Commerces.create_contract(@create_contract_attrs)
       params = Map.put(@create_attrs, :contract_id, contract.id)
-      conn = post conn, contract_detail_path(conn, :create), contract_detail: params
-      assert %{"id" => id} = json_response(conn, 201)["data"]
+      conn = post conn, contract_detail_path(conn, :create), params
+      assert %{"id" => id} = json_response(conn, 201)
 
       conn = get conn, contract_detail_path(conn, :show, id)
-      assert json_response(conn, 200)["data"] == %{
+      assert json_response(conn, 200)
+             |> Map.delete("updated_at")
+             |> Map.delete("inserted_at") == %{
         "id" => id,
         "amount" => 42,
         "category1" => "some category1",
@@ -45,20 +47,25 @@ defmodule MateriaCommerceWeb.ContractDetailControllerTest do
         "category4" => "some category4",
         "color" => "some color",
         "contract_name" => "some contract_name",
+        "contract_no" => "some contract_no",
         "delivery_area" => "some delivery_area",
         "description" => "some description",
+        "end_datetime" => "2010-04-17T23:00:00.000000+09:00",
         "image_url" => "some image_url",
         "item_code" => "some item_code",
         "jan_code" => "some jan_code",
-        "lock_version" => 0,
+        "lock_version" => 42,
         "manufacturer" => "some manufacturer",
+        "merchandise_cost" => "120.5",
         "model_number" => "some model_number",
         "name" => "some name",
-        "price" => 42,
+        "price" => "120.5",
+        "purchase_amount" => "120.5",
         "size1" => "some size1",
         "size2" => "some size2",
         "size3" => "some size3",
         "size4" => "some size4",
+        "start_datetime" => "2010-04-17T23:00:00.000000+09:00",
         "tax_category" => "some tax_category",
         "thumbnail" => "some thumbnail",
         "weight1" => "some weight1",
@@ -77,11 +84,13 @@ defmodule MateriaCommerceWeb.ContractDetailControllerTest do
     setup [:create_contract_detail]
 
     test "renders contract_detail when data is valid", %{conn: conn, contract_detail: %ContractDetail{id: id} = contract_detail} do
-      conn = put conn, contract_detail_path(conn, :update, contract_detail), contract_detail: @update_attrs
-      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+      conn = put conn, contract_detail_path(conn, :update, contract_detail), @update_attrs
+      assert %{"id" => ^id} = json_response(conn, 200)
 
       conn = get conn, contract_detail_path(conn, :show, id)
-      assert json_response(conn, 200)["data"] == %{
+      assert json_response(conn, 200)
+             |> Map.delete("updated_at")
+             |> Map.delete("inserted_at") == %{
         "id" => id,
         "amount" => 43,
         "category1" => "some updated category1",
@@ -90,20 +99,25 @@ defmodule MateriaCommerceWeb.ContractDetailControllerTest do
         "category4" => "some updated category4",
         "color" => "some updated color",
         "contract_name" => "some updated contract_name",
+        "contract_no" => "some updated contract_no",
         "delivery_area" => "some updated delivery_area",
         "description" => "some updated description",
+        "end_datetime" => "2011-05-19T00:01:01.000000+09:00",
         "image_url" => "some updated image_url",
         "item_code" => "some updated item_code",
         "jan_code" => "some updated jan_code",
-        "lock_version" => 1,
+        "lock_version" => 43,
         "manufacturer" => "some updated manufacturer",
+        "merchandise_cost" => "456.7",
         "model_number" => "some updated model_number",
         "name" => "some updated name",
-        "price" => 43,
+        "price" => "456.7",
+        "purchase_amount" => "456.7",
         "size1" => "some updated size1",
         "size2" => "some updated size2",
         "size3" => "some updated size3",
         "size4" => "some updated size4",
+        "start_datetime" => "2011-05-19T00:01:01.000000+09:00",
         "tax_category" => "some updated tax_category",
         "thumbnail" => "some updated thumbnail",
         "weight1" => "some updated weight1",


### PR DESCRIPTION
ContractDetailはcontract_idでAssociationしていたが､contract_noに変更｡
→それに伴い､定義関連は修正｡

get_current_contract_detail_history
delete_future_contract_detail_histories
get_recent_contract_detail_history
create_new_contract_detail_history
→上記の､ヒストリカルテーブル用メソッド実装｡

get_current_commerces
→contractとcontract_detailをあわせて取得するメソッド実装
