### PR TITLE
StaleEntryErrorがKeyErrorになる問題

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -50,6 +50,8 @@ config :guardian, Guardian.DB,
 # Configures gettext for Materia
 config :materia, :repo, MateriaCommerce.Test.Repo
 
+config :materia, gettext: MateriaCommerceWeb.Gettext
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"

--- a/lib/materia_commerce/commerces/commerces.ex
+++ b/lib/materia_commerce/commerces/commerces.ex
@@ -474,7 +474,7 @@ defmodule MateriaCommerce.Commerces do
         # 楽観排他チェック
         _ = cond do
           !Map.has_key?(attr, "lock_version") -> raise KeyError, message: "parameter have not lock_version"
-          attr["lock_version"] != recent_contract.lock_version -> raise Ecto.StaleEntryError, message: "attempted to update a stale entry"
+          attr["lock_version"] != recent_contract.lock_version -> raise Ecto.StaleEntryError, struct: nil, action: "update", message: "attempted to update a stale entry"
           true -> :ok
         end
 
@@ -1053,7 +1053,7 @@ defmodule MateriaCommerce.Commerces do
                  Map.has_key?(attr, "id") and !Map.has_key?(attr, "lock_version") ->
                    raise KeyError, message: "parameter have not lock_version"
                  Map.has_key?(attr, "id") and !check_recent_contract_detail(recent_contract_detail, attr["id"], attr["lock_version"]) ->
-                   raise Ecto.StaleEntryError, message: "attempted to update a stale entry"
+                   raise Ecto.StaleEntryError, struct: nil, action: "update", message: "attempted to update a stale entry"
                  true -> :ok
                end
              end
@@ -2047,7 +2047,7 @@ defmodule MateriaCommerce.Commerces do
           !Map.has_key?(attr, "lock_version") ->
             raise KeyError, message: "parameter have not lock_version"
           attr["lock_version"] != recent.lock_version ->
-            raise Ecto.StaleEntryError, message: "attempted to update a stale entry"
+            raise Ecto.StaleEntryError, struct: nil, action: "update", message: "attempted to update a stale entry"
           true -> :ok
         end
 
@@ -2235,7 +2235,7 @@ defmodule MateriaCommerce.Commerces do
                  Map.has_key?(attr, "id") and !Map.has_key?(attr, "lock_version") ->
                    raise KeyError, message: "parameter have not lock_version"
                  Map.has_key?(attr, "id") and !check_recent_request_appendix(recent_request_appendix, attr["id"], attr["lock_version"]) ->
-                   raise Ecto.StaleEntryError, message: "attempted to update a stale entry"
+                   raise Ecto.StaleEntryError, struct: nil, action: "update", message: "attempted to update a stale entry"
                  true -> :ok
                end
              end

--- a/lib/materia_commerce/products/products.ex
+++ b/lib/materia_commerce/products/products.ex
@@ -217,8 +217,10 @@ defmodule MateriaCommerce.Products do
     else
       # 2回目以降のヒストリー登録の場合
       # 楽観排他チェック
-      if !Map.has_key?(attr, "lock_version") || attr["lock_version"] != recent_item.lock_version do
-        raise Ecto.StaleEntryError, message: "attempted to update a stale entry"
+      _ = cond do
+        !Map.has_key?(attr, "lock_version") -> raise KeyError, message: "parameter have not lock_version"
+        attr["lock_version"] != recent_item.lock_version -> raise Ecto.StaleEntryError, struct: nil, action: "update", message: "attempted to update a stale entry"
+        true -> :ok
       end
 
       attr = Map.keys(attr)
@@ -395,7 +397,7 @@ defmodule MateriaCommerce.Products do
        # 楽観排他チェック
        _ = cond do
         !Map.has_key?(attr, "lock_version") -> raise KeyError, message: "parameter have not lock_version"
-        attr["lock_version"] != recent_tax.lock_version -> raise Ecto.StaleEntryError, message: "attempted to update a stale entry"
+        attr["lock_version"] != recent_tax.lock_version -> raise Ecto.StaleEntryError, struct: nil, action: "update", message: "attempted to update a stale entry"
         true -> :ok
        end
  
@@ -647,7 +649,7 @@ defmodule MateriaCommerce.Products do
         # 楽観排他チェック
         _ = cond do
           !Map.has_key?(attr, "lock_version") -> raise KeyError, message: "parameter have not lock_version"
-          attr["lock_version"] != recent_price.lock_version -> raise Ecto.StaleEntryError, message: "attempted to update a stale entry"
+          attr["lock_version"] != recent_price.lock_version -> raise Ecto.StaleEntryError, struct: nil, action: "update", message: "attempted to update a stale entry"
           true -> :ok
         end
 

--- a/test/materia_commerce/commerces/commerces_test.exs
+++ b/test/materia_commerce/commerces/commerces_test.exs
@@ -105,7 +105,7 @@ defmodule MateriaCommerce.CommercesTest do
         "status" => 4,
         "lock_version" => 99,
       }
-      assert_raise(KeyError, fn -> MateriaCommerce.Commerces.create_new_contract_history(%{}, base_datetime, keywords, attr, 1) end)
+      assert_raise(Ecto.StaleEntryError, fn -> MateriaCommerce.Commerces.create_new_contract_history(%{}, base_datetime, keywords, attr, 1) end)
     end
 
     test "create_new_contract_history/4 create data all delete" do
@@ -419,7 +419,7 @@ defmodule MateriaCommerce.CommercesTest do
           "contract_name" => "TEST1"
         }
       ]
-      assert_raise(KeyError, fn -> MateriaCommerce.Commerces.create_new_contract_detail_history(%{}, base_datetime, keywords, attrs, 1) end)
+      assert_raise(Ecto.StaleEntryError, fn -> MateriaCommerce.Commerces.create_new_contract_detail_history(%{}, base_datetime, keywords, attrs, 1) end)
     end
 
     test "create_new_contract_detail_history/4 create data all delete" do
@@ -879,7 +879,7 @@ defmodule MateriaCommerce.CommercesTest do
         "status" => 4,
         "lock_version" => 99,
       }
-      assert_raise(KeyError, fn -> MateriaCommerce.Commerces.create_new_request_history(%{}, base_datetime, keywords, attr, 1) end)
+      assert_raise(Ecto.StaleEntryError, fn -> MateriaCommerce.Commerces.create_new_request_history(%{}, base_datetime, keywords, attr, 1) end)
     end
 
     test "create_new_request_history/5 create data all delete" do
@@ -1159,7 +1159,7 @@ defmodule MateriaCommerce.CommercesTest do
           "appendix_category" => "Category5"
         }
       ]
-      assert_raise(KeyError, fn -> MateriaCommerce.Commerces.create_new_request_appendix_history(%{}, base_datetime, keywords, attrs, 1) end)
+      assert_raise(Ecto.StaleEntryError, fn -> MateriaCommerce.Commerces.create_new_request_appendix_history(%{}, base_datetime, keywords, attrs, 1) end)
     end
 
     test "create_new_request_appendix_history/5 create data all delete" do

--- a/test/materia_commerce/products/products_test.exs
+++ b/test/materia_commerce/products/products_test.exs
@@ -107,7 +107,7 @@ defmodule MateriaCommerce.ProductsTest do
         "lock_version" => 99,
         "tax_rate"=> 0.3,
       }
-      assert_raise(KeyError, fn -> Products.create_new_tax_history(%{}, base_datetime, [{:tax_category, "category1"}], attr, 1) end)
+      assert_raise(Ecto.StaleEntryError, fn -> Products.create_new_tax_history(%{}, base_datetime, [{:tax_category, "category1"}], attr, 1) end)
     end
 
     test "create_new_tax_history/4 create data" do
@@ -267,7 +267,7 @@ defmodule MateriaCommerce.ProductsTest do
         "unit_price"=> 150,
         "lock_version" => 99,
       }
-      assert_raise(KeyError, fn -> Products.create_new_price_history(%{}, base_datetime, [{:item_code, "ICZ1000"}], attr, 1) end)
+      assert_raise(Ecto.StaleEntryError, fn -> Products.create_new_price_history(%{}, base_datetime, [{:item_code, "ICZ1000"}], attr, 1) end)
     end
 
     test "create_new_price_history/4 create data" do


### PR DESCRIPTION
ヒストリカルテーブルのLock_version違いでEcto.StaleEntryErrorをRaiseしてる処理で最終的に受け取る例外は､KeyErrorが返っている｡

Ecto.StaleEntryError側で特定のキー(:struct, :action)がなく､KeyErrorがRaiseされてるので､
特定のキーを追加した｡

